### PR TITLE
Change all example_Lighting testApp → ofApp

### DIFF
--- a/example_Lighting/example_Lighting.cbp
+++ b/example_Lighting/example_Lighting.cbp
@@ -48,10 +48,10 @@
 		<Unit filename="src/main.cpp">
 			<Option virtualFolder="src/" />
 		</Unit>
-		<Unit filename="src/testApp.cpp">
+		<Unit filename="src/ofApp.cpp">
 			<Option virtualFolder="src/" />
 		</Unit>
-		<Unit filename="src/testApp.h">
+		<Unit filename="src/ofApp.h">
 			<Option virtualFolder="src/" />
 		</Unit>
 		<Extensions>

--- a/example_Lighting/example_Lighting.layout
+++ b/example_Lighting/example_Lighting.layout
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <CodeBlocks_layout_file>
 	<ActiveTarget name="Debug" />
-	<File name="src/testApp.h" open="0" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="src/ofApp.h" open="0" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
 			<Cursor1 position="800" topLine="8" />
 		</Cursor>
@@ -11,7 +11,7 @@
 			<Cursor1 position="544" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="src/testApp.cpp" open="1" top="1" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="src/ofApp.cpp" open="1" top="1" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
 			<Cursor1 position="2768" topLine="10" />
 		</Cursor>

--- a/example_Lighting/src/main.cpp
+++ b/example_Lighting/src/main.cpp
@@ -1,5 +1,5 @@
 #include "ofMain.h"
-#include "testApp.h"
+#include "ofApp.h"
 
 #define USE_PROGRAMMABLE_GL
 #ifdef USE_PROGRAMMABLE_GL

--- a/example_Lighting/src/ofApp.cpp
+++ b/example_Lighting/src/ofApp.cpp
@@ -1,7 +1,7 @@
-#include "testApp.h"
+#include "ofApp.h"
 
 //--------------------------------------------------------------
-void testApp::setup(){
+void ofApp::setup(){
     ofSetLogLevel(OF_LOG_VERBOSE);
     //disable vertical Sync is too bad with light sometimes
     ofSetVerticalSync(true);
@@ -65,12 +65,12 @@ void testApp::setup(){
 }
 
 //--------------------------------------------------------------
-void testApp::update(){
+void ofApp::update(){
 
 }
 
 //--------------------------------------------------------------
-void testApp::draw(){
+void ofApp::draw(){
 
     cam.begin();
 
@@ -113,7 +113,7 @@ void testApp::draw(){
 }
 
 //--------------------------------------------------------------
-void testApp::keyPressed(int key){
+void ofApp::keyPressed(int key){
     ofVec3f pos;
 
     switch (key) {
@@ -205,41 +205,41 @@ void testApp::keyPressed(int key){
 }
 
 //--------------------------------------------------------------
-void testApp::keyReleased(int key){
+void ofApp::keyReleased(int key){
 
 }
 
 //--------------------------------------------------------------
-void testApp::mouseMoved(int x, int y ){
+void ofApp::mouseMoved(int x, int y ){
 
 }
 
 //--------------------------------------------------------------
-void testApp::mouseDragged(int x, int y, int button){
+void ofApp::mouseDragged(int x, int y, int button){
 
 }
 
 //--------------------------------------------------------------
-void testApp::mousePressed(int x, int y, int button){
+void ofApp::mousePressed(int x, int y, int button){
 
 }
 
 //--------------------------------------------------------------
-void testApp::mouseReleased(int x, int y, int button){
+void ofApp::mouseReleased(int x, int y, int button){
 
 }
 
 //--------------------------------------------------------------
-void testApp::windowResized(int w, int h){
+void ofApp::windowResized(int w, int h){
 
 }
 
 //--------------------------------------------------------------
-void testApp::gotMessage(ofMessage msg){
+void ofApp::gotMessage(ofMessage msg){
 
 }
 
 //--------------------------------------------------------------
-void testApp::dragEvent(ofDragInfo dragInfo){
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }


### PR DESCRIPTION
I think the original intention was to change all instances to ofApp, so I just finished changing them. Now you can drop this example in Open Frameworks & it compiles just fine!

-----

Note: `develop` is currently behind `master`, which is my I'm submitting a PR directly to `master`.